### PR TITLE
Ports now Disconnect on Deletion

### DIFF
--- a/Assets/Prefabs/Gameplay/Machines/Machine.prefab
+++ b/Assets/Prefabs/Gameplay/Machines/Machine.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4590213518212070741}
   - component: {fileID: 4590213518212070742}
   - component: {fileID: 4590213518212070743}
+  - component: {fileID: 8303644587406122049}
   - component: {fileID: 8714590015041616768}
   m_Layer: 6
   m_Name: Machine
@@ -96,10 +97,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15172d99f8794f55ae32e6a6bed50ca6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  recipe: {fileID: 0}
   recipeObj: {fileID: 0}
   _shouldPrint: 0
   _shouldBreak: 0
+--- !u!114 &8303644587406122049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4590213518212070728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdbcc56d2daaadb4e8aa727b2ffa441b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!61 &8714590015041616768
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Gameplay/Machines/Machine.cs
+++ b/Assets/Scripts/Gameplay/Machines/Machine.cs
@@ -12,7 +12,7 @@ public class Machine : Draggable {
     [NonSerialized] public List<InputPort> InputPorts = new List<InputPort>();
     private int _ticksSinceProduced;
     private bool _pokedThisTick;
-    public bool _isActive;
+    public bool _isActive = true;
 
     /// <summary>
     /// A list of resources that this machine just produced this tick.

--- a/Assets/Scripts/Gameplay/Machines/Machine.cs
+++ b/Assets/Scripts/Gameplay/Machines/Machine.cs
@@ -370,6 +370,40 @@ public class Machine : Draggable {
         }
         return ret;
     }
+
+    public void OnDestruction()
+    {
+        foreach (OutputPort port in OutputPorts) {
+            port.ConnectedMachine.RemoveInput(this);
+        }
+        foreach (InputPort port in InputPorts) {
+            port.ConnectedMachine.RemoveOutput(this);
+        }
+        OutputPorts.Clear();
+        InputPorts.Clear();
+    }
+
+    public void RemoveOutput(Machine m)
+    {
+        foreach (OutputPort port in OutputPorts) {
+            if (port.ConnectedMachine.Equals(m))
+            {
+                OutputPorts.Remove(port);
+                break;
+            }
+        }
+    }
+
+    public void RemoveInput(Machine m)
+    {
+        foreach (InputPort port in InputPorts) {
+            if (port.ConnectedMachine.Equals(m))
+            {
+                InputPorts.Remove(port);
+                break;
+            }
+        }
+    }
     
     public List<ConveyorBlueprint> RenderConveyorBluePrintLine(int n, Vector3 startPos, Vector2 dir) {
         return RenderConveyorBluePrintLine(n, startPos, dir, Vector2.zero);

--- a/Assets/Scripts/Gameplay/Machines/Machine.cs
+++ b/Assets/Scripts/Gameplay/Machines/Machine.cs
@@ -12,6 +12,7 @@ public class Machine : Draggable {
     [NonSerialized] public List<InputPort> InputPorts = new List<InputPort>();
     private int _ticksSinceProduced;
     private bool _pokedThisTick;
+    public bool _isActive;
 
     /// <summary>
     /// A list of resources that this machine just produced this tick.
@@ -170,6 +171,11 @@ public class Machine : Draggable {
     /// Produces output if needed.
     /// </summary>
     public void Tick() {
+        if (!_isActive)
+        {
+            OnDestruction();
+        }
+
         if (!_pokedThisTick) {
             _pokedThisTick = true;
             bool enoughInput = _checkEnoughInput();

--- a/Assets/Scripts/ResourceHierarchy/Interaction/Base/NormalDestroy.cs
+++ b/Assets/Scripts/ResourceHierarchy/Interaction/Base/NormalDestroy.cs
@@ -8,6 +8,7 @@ public class NormalDestroy : Destructable
     //Called when the object is destroyed
     public override void OnDestruct()
     {
+        gameObject.GetComponent<Machine>().OnDestruction();
         gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
# Description
The prefab for Machine also now contains the Normal Destruction script, so they should all be destroyable. If this causes merge conflicts, just remove the change to it. Other than that, for some reason the ConveyorBlueprint is no longer in the Pooler Script, but I'm not sure how to fix that without causing merge conflicts. There is also now an _isActive boolean in Machine that will disconnect the machine from everything on it's next tick. _isActive now starts as true now, so it doesn't immediately disconnect the machine.

# Related Task
[(Put the link to the card here)](https://trello.com/c/APJ0mSsN/36-disconnect-machines-on-deletion)

# How Has This Been Tested?
I tested this with both machines, and the conveyor belts, and it works as intended. I also toggled the _isActive just to check

# Screenshots/video (if appropriate):
(I use streamable to share video: https://streamable.com/)

Don't forget to @ me in your team's channel with the link to this pull request and any images/video!
