### PR TITLE
Screen Shake + Beat Bar Speed Re-Fix

### DIFF
--- a/Assets/Animation/Lock.controller
+++ b/Assets/Animation/Lock.controller
@@ -117,7 +117,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Prefabs/Gameplay/Rooms/Locked Room.prefab
+++ b/Assets/Prefabs/Gameplay/Rooms/Locked Room.prefab
@@ -439,14 +439,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c533c867743b62b45b1923f418344250, type: 3}
---- !u!224 &8068300788908062507 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7115808287695022719, guid: c533c867743b62b45b1923f418344250, type: 3}
-  m_PrefabInstance: {fileID: 952565465191406932}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3058426951190455028 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2830941338532970400, guid: c533c867743b62b45b1923f418344250, type: 3}
+  m_PrefabInstance: {fileID: 952565465191406932}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8068300788908062507 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7115808287695022719, guid: c533c867743b62b45b1923f418344250, type: 3}
   m_PrefabInstance: {fileID: 952565465191406932}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &971216882472531349
@@ -534,6 +534,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 46c7d593b71545b47bf70198bc64f85d, type: 3}
+--- !u!4 &8051496011627893904 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7117618622287913221, guid: 46c7d593b71545b47bf70198bc64f85d, type: 3}
+  m_PrefabInstance: {fileID: 971216882472531349}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8051496011627893906 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7117618622287913223, guid: 46c7d593b71545b47bf70198bc64f85d, type: 3}
@@ -545,11 +550,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15172d99f8794f55ae32e6a6bed50ca6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8051496011627893904 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7117618622287913221, guid: 46c7d593b71545b47bf70198bc64f85d, type: 3}
-  m_PrefabInstance: {fileID: 971216882472531349}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2390524740191504311
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -996,17 +996,6 @@ PrefabInstance:
       objectReference: {fileID: 3431385738032740326}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ffc8499693912f4b87b398ee1190bbf, type: 3}
---- !u!114 &8209930583569934841 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5659093142594496326, guid: 1ffc8499693912f4b87b398ee1190bbf, type: 3}
-  m_PrefabInstance: {fileID: 4568527321278746303}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4c01d1b3139d475bacaedbf506e1eade, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &5720116986689938487 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8072521406734690952, guid: 1ffc8499693912f4b87b398ee1190bbf, type: 3}
@@ -1016,6 +1005,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b6ebc4260cbb4f2eb01c9bd0a710774b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8209930583569934841 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5659093142594496326, guid: 1ffc8499693912f4b87b398ee1190bbf, type: 3}
+  m_PrefabInstance: {fileID: 4568527321278746303}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c01d1b3139d475bacaedbf506e1eade, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4762652344474833894
@@ -1339,11 +1339,6 @@ PrefabInstance:
       objectReference: {fileID: 5895676970962009716}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eb894222aba72884aa9d97040fe065a2, type: 3}
---- !u!4 &6551754890760156586 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1414417743092410376, guid: eb894222aba72884aa9d97040fe065a2, type: 3}
-  m_PrefabInstance: {fileID: 5282026568576114082}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8649823680767334401 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3551052996580312483, guid: eb894222aba72884aa9d97040fe065a2, type: 3}
@@ -1355,6 +1350,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c01d1b3139d475bacaedbf506e1eade, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &6551754890760156586 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1414417743092410376, guid: eb894222aba72884aa9d97040fe065a2, type: 3}
+  m_PrefabInstance: {fileID: 5282026568576114082}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5385586946289029515
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1955,6 +1955,17 @@ PrefabInstance:
       objectReference: {fileID: 8209930583569934841}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d8073aeb333af2c4583010f8f6ee1920, type: 3}
+--- !u!114 &841185566028322535 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8655999284317464244, guid: d8073aeb333af2c4583010f8f6ee1920, type: 3}
+  m_PrefabInstance: {fileID: 8326087724717764691}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e7fbec450b649ab9e5bf82ee8f4a35d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3431385738032740326 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6634523024244770741, guid: d8073aeb333af2c4583010f8f6ee1920, type: 3}
@@ -1971,17 +1982,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 380936006158914544, guid: d8073aeb333af2c4583010f8f6ee1920, type: 3}
   m_PrefabInstance: {fileID: 8326087724717764691}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &841185566028322535 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8655999284317464244, guid: d8073aeb333af2c4583010f8f6ee1920, type: 3}
-  m_PrefabInstance: {fileID: 8326087724717764691}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0e7fbec450b649ab9e5bf82ee8f4a35d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &8424064686549906148
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2283,6 +2283,25 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 92552aeed9044f8cba5855cdd5ad20a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2215440207846191479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5951824276090157557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9850857faae924a97b3f0306f1881b01, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  positionStrength_s: 0.08
+  rotationStrength_s: 0.1
+  frequency: 25
+  numBounces: 5
+  positionStrength_l: 0.8
+  rotationStrength_l: 0.5
+  duration: 1.5
 --- !u!1001 &9175779758192030171
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/ScreenShake.cs
+++ b/Assets/ScreenShake.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using CameraShake;
+
+public class ScreenShake : MonoBehaviour
+{
+    [Header("Small Screen Shake")]
+    [SerializeField] private float positionStrength_s = 0.08f;
+    [SerializeField] private float rotationStrength_s = 0.1f;
+    [SerializeField] private float frequency = 25f;
+    [SerializeField] private int numBounces = 5;
+    [SerializeField] private float delay_s = 0f;
+
+    [Header("Large Screen Shake")]
+    [SerializeField] private float positionStrength_l = 0.8f;
+    [SerializeField] private float rotationStrength_l = 0.5f;
+    [SerializeField] private float duration = 1.5f;
+    [SerializeField] private float delay_l = 0f;
+
+    /// <summary>
+    /// Shake the screen significantly. (Set the shake parameters in the ScreenShake component.)
+    /// </summary>
+    public void LargeShake()
+    {
+        CameraShaker.Presets.Explosion2D(positionStrength_l, rotationStrength_l, duration);
+    }
+
+    /// <summary>
+    /// Shake the screen significantly after a set delay. (Set the delay length and shake parameters in the ScreenShake component.)
+    /// </summary>
+    public void DelayedLargeShake()
+    {
+        Invoke("LargeShake", delay_l);
+    }
+
+    /// <summary>
+    /// Shake the screen a little. (Set the shake parameters in the ScreenShake component.)
+    /// </summary>
+    public void SmallShake()
+    {
+        CameraShaker.Presets.ShortShake2D(positionStrength_s, rotationStrength_s, frequency, numBounces);
+    }
+
+    /// <summary>
+    /// Shake the screen a little after a set delay. (Set the delay length and shake parameters in the ScreenShake component.)
+    /// </summary>
+    public void DelayedSmallShake()
+    {
+        Invoke("SmallShake", delay_s);
+    }
+}

--- a/Assets/ScreenShake.cs.meta
+++ b/Assets/ScreenShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9850857faae924a97b3f0306f1881b01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/UnlockableSquares.cs
+++ b/Assets/Scripts/Gameplay/UnlockableSquares.cs
@@ -25,6 +25,7 @@ public class UnlockableSquares : MonoBehaviour
     [SerializeField]
     private GameObject lockSpriteObj;
     private Lock _lockSprite;
+    private ScreenShake ScreenShake;
 
     public Material LockMat;
     private Material _lockMat;
@@ -52,6 +53,7 @@ public class UnlockableSquares : MonoBehaviour
 
         _canvas = GetComponentInChildren<Canvas>();
         _lockSprite = GetComponentInChildren<Lock>();
+        ScreenShake = GetComponent<ScreenShake>();
     }
     
     void Update() {
@@ -88,6 +90,7 @@ public class UnlockableSquares : MonoBehaviour
 
         if (_lockSprite) {
             _lockSprite.Unlock();
+            ScreenShake.DelayedLargeShake();
         }
 
         UnlockEvent.Invoke();

--- a/Assets/Scripts/Graphics and UI/Beat Bar/BeatBar.cs
+++ b/Assets/Scripts/Graphics and UI/Beat Bar/BeatBar.cs
@@ -11,10 +11,10 @@ public class BeatBar : MonoBehaviour {
     public Vector3 StartPos { get; private set; }
     public Vector3 EndPos { get; private set; }
 
-    [Header("Math for beatline movement calculations")]
+    [Header("Beat Line Movement")]
     
-    [Tooltip("The amount of time a player can press before the beat line touches the end zone. Multiplied by seconds/beat")]
-    [SerializeField] private float _graceTime = 0.1f;
+    [Tooltip("The amount of time, in beats, that a beat line will exist on the beat bar.")]
+    [SerializeField] private int beatLineDuration = 8;
 
     //The amount of time it takes for a beat line to dissipate after stopping. Multiplied by seconds/beat
     public float DissolveTime { get; } = 0.1f;
@@ -38,14 +38,14 @@ public class BeatBar : MonoBehaviour {
     }
 
     public double GetVelocity() {
+
         double secPerBeat = Conductor.Instance.BeatClipHelper.BeatClip.SecPerBeat;
 
-        // Represents the total time between the moment a beatline starts to exist and the moment it reaches
-        // The center of the endzone
-        double timeElapsed = 3 * secPerBeat + Conductor.Instance.BeatClipHelper.BeatClip.BeatOffset;
+        // The time we want between the beat line's appearance and it reaching it the end zone
+        double timeElapsed = beatLineDuration * secPerBeat + Conductor.Instance.BeatClipHelper.BeatClip.BeatOffset;
 
+        // Do not change this formula if you want beat lines to be on time.
         double v = (StartPos.x-EndPos.x)/(timeElapsed);
-        v /= 2;
         return v;
     }
 

--- a/Assets/Scripts/Graphics and UI/CameraFollow.cs
+++ b/Assets/Scripts/Graphics and UI/CameraFollow.cs
@@ -12,9 +12,6 @@ public class CameraFollow : MonoBehaviour {
     private float _smoothSpeed = 40f;
     private Vector2 _velocity = Vector2.zero;
 
-    private Vector3 shakeVector = Vector3.zero;
-    private Vector3 previousShakeVector = Vector3.zero;
-
     private void Awake()
     {
         _smoothSpeed = 40f;
@@ -55,110 +52,7 @@ public class CameraFollow : MonoBehaviour {
 
         Vector2 desiredPosition = Target.position;
         Vector2 smoothedPosition 
-            = Vector2.SmoothDamp(transform.position - previousShakeVector, desiredPosition, ref _velocity, _smoothSpeed * Time.deltaTime);
-        Vector3 newPosition = new Vector3(smoothedPosition.x, smoothedPosition.y, transform.position.z) + shakeVector;
-        transform.position = newPosition;
+            = Vector2.SmoothDamp(transform.position, desiredPosition, ref _velocity, _smoothSpeed * Time.deltaTime);
+        transform.position = new Vector3(smoothedPosition.x, smoothedPosition.y, transform.position.z);
     }
-
-
-
-    /// <summary>
-    /// Shakes the screen in according to the parameters given.
-    /// </summary>
-    /// <param name="severity">The distance of the first shake.</param>
-    /// <param name="numShakes">The number of shakes that occur.</param>
-    /// <param name="duration">The duration of the entire shaking.</param>
-    /// <param name="direction">The direction of the first shake.</param>
-    /// <param name="randomness">The tendency of the shakes to move randomly.</param>
-    public void ShakeScreen(float severity, int numShakes, float duration, Vector3 direction, float randomness)
-    {
-        StartCoroutine(ScreenShake(severity, numShakes, duration, direction, randomness));
-    }
-
-    /// <summary>
-    /// Shakes the screen a little in a random direction. (Uses 0.03f, 3, 0.2f, a random 2D vector, and 0.1f)
-    /// </summary> 
-    public void SmallShake()
-    {
-        StartCoroutine(ScreenShake(0.03f, 3, 0.2f, Random.insideUnitCircle.normalized, 0.1f));
-    }
-
-    /// <summary>
-    /// Shakes the screen a little, starting in the direction specified. (Uses 0.05f, 3, 0.3f, your direction, and 0.1f)
-    /// </summary> 
-    public void SmallShake(Vector3 direction)
-    {
-        StartCoroutine(ScreenShake(0.05f, 3, 0.3f, direction, 0.1f));
-    }
-
-    readonly AnimationCurve moveCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-    
-    private IEnumerator ScreenShake(float severity, int numShakes, float duration, Vector3 direction, float randomness)
-    {
-        int shakeIndex = 0;
-        float shakeProgress = 0f;
-        float shakeDuration = duration / numShakes;
-
-        Vector3 previousShakePath = Vector3.zero;
-        Vector3 shakePath = direction.normalized * severity * Mathf.Pow((1 - (float)shakeIndex / numShakes), 2);
-
-        while (shakeIndex < numShakes)
-        {
-            if (shakeProgress < 1f)
-            {
-                shakeProgress += Time.deltaTime / shakeDuration;
-
-                previousShakeVector = shakeVector;
-                shakeVector = (moveCurve.Evaluate(shakeProgress) * (shakePath - previousShakePath)) + previousShakePath;
-            }
-            else
-            {
-                shakeProgress = 0;
-
-                previousShakeVector = shakeVector;
-                shakeVector = shakePath;
-
-                shakeIndex++;
-                if (shakeIndex < numShakes)
-                {
-                    Vector3 randomAdjustmentVector = Random.insideUnitCircle.normalized * randomness;
-
-                    previousShakePath = shakePath;
-                    shakePath = (-shakePath.normalized + randomAdjustmentVector).normalized * severity * Mathf.Pow((1 - (float)shakeIndex/numShakes),2);
-                }
-            }
-
-            yield return 0;
-        }
-
-        previousShakeVector = shakeVector;
-        shakeVector = Vector3.zero;
-
-        yield return 0;
-        previousShakeVector = Vector3.zero;
-    }
-
-    // For testing purposes, this Update code calls regular shakes so you can try out different shakes.
-    /*
-    [Header("Screen Shake Parameters")]
-    [SerializeField] private float period = 0.48f;
-    [SerializeField] private float severity = 0.05f;
-    [SerializeField] private int numShakes = 6;
-    [SerializeField] private float duration = 0.2f;
-
-    bool shook = false;
-    public void Update()
-    {
-        if (Time.time % period < 0.15f && !shook)
-        {
-            shook = true;
-            ShakeScreen(severity, numShakes, duration);
-        }
-
-        if (Time.time % period > period - 0.15f && shook)
-        {
-            shook = false;
-        }
-    }
-    */
 }

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1bfb6a4682934f44be265da6de48898
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 721197a8e82a4304097f3e0991293e4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Attenuator.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Attenuator.cs
@@ -1,0 +1,66 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    /// <summary>
+    /// Contains methods for changing strength and direction of shakes depending on their position.
+    /// </summary>
+    public static class Attenuator
+    {
+        /// <summary>
+        /// Returns multiplier for the strength of a shake, based on source and camera positions.
+        /// </summary>
+        public static float Strength(StrengthAttenuationParams pars, Vector3 sourcePosition, Vector3 cameraPosition)
+        {
+            Vector3 vec = cameraPosition - sourcePosition;
+            float distance = Vector3.Scale(pars.axesMultiplier, vec).magnitude;
+            float strength = Mathf.Clamp01(1 - (distance - pars.clippingDistance) / pars.falloffScale);
+
+            return Power.Evaluate(strength, pars.falloffDegree);
+        }
+
+        /// <summary>
+        /// Returns displacement, opposite to the direction to the source in camera's local space.
+        /// </summary>
+        public static Displacement Direction(Vector3 sourcePosition, Vector3 cameraPosition, Quaternion cameraRotation)
+        {
+            Displacement direction = Displacement.Zero;
+            direction.position = (cameraPosition - sourcePosition).normalized;
+            direction.position = Quaternion.Inverse(cameraRotation) * direction.position;
+
+            direction.eulerAngles.x = direction.position.z;
+            direction.eulerAngles.y = direction.position.x;
+            direction.eulerAngles.z = -direction.position.x;
+
+            return direction;
+        }
+
+        [System.Serializable]
+        public class StrengthAttenuationParams
+        {
+            /// <summary>
+            /// Radius in which shake doesn't lose strength.
+            /// </summary>
+            [Tooltip("Radius in which shake doesn't lose strength.")]
+            public float clippingDistance = 10;
+
+            /// <summary>
+            /// Defines how fast strength falls with distance.
+            /// </summary>
+            [Tooltip("How fast strength falls with distance.")]
+            public float falloffScale = 50;
+
+            /// <summary>
+            /// Power of the falloff function.
+            /// </summary>
+            [Tooltip("Power of the falloff function.")]
+            public Degree falloffDegree = Degree.Quadratic;
+
+            /// <summary>
+            /// Contribution of each axis to distance. E. g. (1, 1, 0) for a 2D game in XY plane.
+            /// </summary>
+            [Tooltip("Contribution of each axis to distance. E. g. (1, 1, 0) for a 2D game in XY plane.")]
+            public Vector3 axesMultiplier = Vector3.one;
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Attenuator.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Attenuator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07aa6a8400d46274f9cbc5f3714e6a9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/BounceShake.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/BounceShake.cs
@@ -1,0 +1,133 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    public class BounceShake : ICameraShake
+    {
+        readonly Params pars;
+        readonly AnimationCurve moveCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        readonly Vector3? sourcePosition = null;
+
+        float attenuation = 1;
+        Displacement direction;
+        Displacement previousWaypoint;
+        Displacement currentWaypoint;
+        int bounceIndex;
+        float t;
+
+        /// <summary>
+        /// Creates an instance of BounceShake.
+        /// </summary>
+        /// <param name="parameters">Parameters of the shake.</param>
+        /// <param name="sourcePosition">World position of the source of the shake.</param>
+        public BounceShake(Params parameters, Vector3? sourcePosition = null)
+        {
+            this.sourcePosition = sourcePosition;
+            pars = parameters;
+            Displacement rnd = Displacement.InsideUnitSpheres();
+            direction = Displacement.Scale(rnd, pars.axesMultiplier).Normalized;
+        }
+
+        /// <summary>
+        /// Creates an instance of BounceShake.
+        /// </summary>
+        /// <param name="parameters">Parameters of the shake.</param>
+        /// <param name="initialDirection">Initial direction of the shake motion.</param>
+        /// <param name="sourcePosition">World position of the source of the shake.</param>
+        public BounceShake(Params parameters, Displacement initialDirection, Vector3? sourcePosition = null)
+        {
+            this.sourcePosition = sourcePosition;
+            pars = parameters;
+            direction = Displacement.Scale(initialDirection, pars.axesMultiplier).Normalized;
+        }
+
+        public Displacement CurrentDisplacement { get; private set; }
+        public bool IsFinished { get; private set; }
+        public void Initialize(Vector3 cameraPosition, Quaternion cameraRotation)
+        {
+            attenuation = sourcePosition == null ?
+                1 : Attenuator.Strength(pars.attenuation, sourcePosition.Value, cameraPosition);
+            currentWaypoint = attenuation * direction.ScaledBy(pars.positionStrength, pars.rotationStrength);
+        }
+
+        public void Update(float deltaTime, Vector3 cameraPosition, Quaternion cameraRotation)
+        {
+            if (t < 1)
+            {
+
+                t += deltaTime * pars.freq;
+                if (pars.freq == 0) t = 1;
+
+                CurrentDisplacement = Displacement.Lerp(previousWaypoint, currentWaypoint,
+                    moveCurve.Evaluate(t));
+            }
+            else
+            {
+                t = 0;
+                CurrentDisplacement = currentWaypoint;
+                previousWaypoint = currentWaypoint;
+                bounceIndex++;
+                if (bounceIndex > pars.numBounces)
+                {
+                    IsFinished = true;
+                    return;
+                }
+
+                Displacement rnd = Displacement.InsideUnitSpheres();
+                direction = -direction
+                    + pars.randomness * Displacement.Scale(rnd, pars.axesMultiplier).Normalized;
+                direction = direction.Normalized;
+                float decayValue = 1 - (float)bounceIndex / pars.numBounces;
+                currentWaypoint = decayValue * decayValue * attenuation
+                    * direction.ScaledBy(pars.positionStrength, pars.rotationStrength);
+            }
+        }
+
+        [System.Serializable]
+        public class Params
+        {
+            /// <summary>
+            /// Strength of the shake for positional axes.
+            /// </summary>
+            [Tooltip("Strength of the shake for positional axes.")]
+            public float positionStrength = 0.05f;
+
+            /// <summary>
+            /// Strength of the shake for rotational axes.
+            /// </summary>
+            [Tooltip("Strength of the shake for rotational axes.")]
+            public float rotationStrength = 0.1f;
+
+            /// <summary>
+            /// Preferred direction of shaking.
+            /// </summary>
+            [Tooltip("Preferred direction of shaking.")]
+            public Displacement axesMultiplier = new Displacement(Vector2.one, Vector3.forward);
+
+            /// <summary>
+            /// Frequency of shaking.
+            /// </summary>
+            [Tooltip("Frequency of shaking.")]
+            public float freq = 25;
+
+            /// <summary>
+            /// Number of vibrations before stop.
+            /// </summary>
+            [Tooltip("Number of vibrations before stop.")]
+            public int numBounces = 5;
+
+            /// <summary>
+            /// Randomness of motion.
+            /// </summary>
+            [Range(0, 1)]
+            [Tooltip("Randomness of motion.")]
+            public float randomness = 0.5f;
+
+            /// <summary>
+            /// How strength falls with distance from the shake source.
+            /// </summary>
+            [Tooltip("How strength falls with distance from the shake source.")]
+            public Attenuator.StrengthAttenuationParams attenuation;
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/BounceShake.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/BounceShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a8a4f5340889954aa6de7013b117066
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShakePresets.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShakePresets.cs
@@ -1,0 +1,67 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    /// <summary>
+    /// Contains shorthands for creating common shake types.
+    /// </summary>
+    public class CameraShakePresets
+    {
+        readonly CameraShaker shaker;
+
+        public CameraShakePresets(CameraShaker shaker)
+        {
+            this.shaker = shaker;
+        }
+
+        /// <summary>
+        /// Suitable for short and snappy shakes in 2D. Moves camera in X and Y axes and rotates it in Z axis. 
+        /// </summary>
+        /// <param name="positionStrength">Strength of motion in X and Y axes.</param>
+        /// <param name="rotationStrength">Strength of rotation in Z axis.</param>
+        /// <param name="freq">Frequency of shaking.</param>
+        /// <param name="numBounces">Number of vibrations before stop.</param>
+        public void ShortShake2D(
+            float positionStrength = 0.08f,
+            float rotationStrength = 0.1f,
+            float freq = 25,
+            int numBounces = 5)
+        {
+            BounceShake.Params pars = new BounceShake.Params
+            {
+                positionStrength = positionStrength,
+                rotationStrength = rotationStrength,
+                freq = freq,
+                numBounces = numBounces
+            };
+            shaker.RegisterShake(new BounceShake(pars));
+        }
+
+        /// <summary>
+        /// Suitable for longer and stronger shakes in 2D. Moves camera in X and Y axes and rotates it in Z axis.
+        /// </summary>
+        /// <param name="positionStrength">Strength of motion in X and Y axes.</param>
+        /// <param name="rotationStrength">Strength of rotation in Z axis.</param>
+        /// <param name="duration">Duration of the shake.</param>
+        public void Explosion2D(
+            float positionStrength = 1f,
+            float rotationStrength = 3,
+            float duration = 0.5f)
+        {
+            PerlinShake.NoiseMode[] modes =
+            {
+                new PerlinShake.NoiseMode(8, 1),
+                new PerlinShake.NoiseMode(20, 0.3f)
+            };
+            Envelope.EnvelopeParams envelopePars = new Envelope.EnvelopeParams();
+            envelopePars.decay = duration <= 0 ? 1 : 1 / duration;
+            PerlinShake.Params pars = new PerlinShake.Params
+            {
+                strength = new Displacement(new Vector3(1, 1) * positionStrength, Vector3.forward * rotationStrength),
+                noiseModes = modes,
+                envelope = envelopePars,
+            };
+            shaker.RegisterShake(new PerlinShake(pars));
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShakePresets.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShakePresets.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27cd455dd46fc6a47b7cc4f29f710304
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShaker.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShaker.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace CameraShake
+{
+    /// <summary>
+    /// Camera shaker component registeres new shakes, holds a list of active shakes, and applies them to the camera additively.
+    /// </summary>
+    public class CameraShaker : MonoBehaviour
+    {
+        public static CameraShaker Instance;
+        public static CameraShakePresets Presets;
+
+        readonly List<ICameraShake> activeShakes = new List<ICameraShake>();
+
+        [Tooltip("Transform which will be affected by the shakes.\n\nCameraShaker will set this transform's local position and rotation.")]
+        [SerializeField]
+        Transform cameraTransform;
+        
+
+        [Tooltip("Scales the strength of all shakes.")]
+        [Range(0, 1)]
+        [SerializeField]
+        public float StrengthMultiplier = 1;
+
+        public CameraShakePresets ShakePresets;
+
+
+        /// <summary>
+        /// Adds a shake to the list of active shakes.
+        /// </summary>
+        public static void Shake(ICameraShake shake)
+        {
+            if (IsInstanceNull()) return;
+            Instance.RegisterShake(shake);
+        }
+
+        /// <summary>
+        /// Adds a shake to the list of active shakes.
+        /// </summary>
+        public void RegisterShake(ICameraShake shake)
+        {
+            shake.Initialize(cameraTransform.position,
+                cameraTransform.rotation);
+            activeShakes.Add(shake);
+        }
+
+        /// <summary>
+        /// Sets the transform which will be affected by the shakes.
+        /// </summary>
+        public void SetCameraTransform(Transform cameraTransform)
+        {
+            cameraTransform.localPosition = Vector3.zero;
+            cameraTransform.localEulerAngles = Vector3.zero;
+            this.cameraTransform = cameraTransform;
+        }
+
+        private void Awake()
+        {
+            Instance = this;
+            ShakePresets = new CameraShakePresets(this);
+            Presets = ShakePresets;
+            if (cameraTransform == null)
+                cameraTransform = transform;
+        }
+
+        private void Update()
+        {
+            if (cameraTransform == null) return;
+
+            Displacement cameraDisplacement = Displacement.Zero;
+            for (int i = activeShakes.Count - 1; i >= 0; i--)
+            {
+                if (activeShakes[i].IsFinished)
+                {
+                    activeShakes.RemoveAt(i);
+                }
+                else
+                {
+                    activeShakes[i].Update(Time.deltaTime, cameraTransform.position, cameraTransform.rotation);
+                    cameraDisplacement += activeShakes[i].CurrentDisplacement;
+                }
+            }
+            cameraTransform.localPosition = StrengthMultiplier * cameraDisplacement.position;
+            cameraTransform.localRotation = Quaternion.Euler(StrengthMultiplier * cameraDisplacement.eulerAngles);
+        }
+
+        private static bool IsInstanceNull()
+        {
+            if (Instance == null)
+            {
+                Debug.LogError("CameraShaker Instance is missing!");
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShaker.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/CameraShaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a257897ce04dc64eb5ae266c62846be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Displacement.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Displacement.cs
@@ -1,0 +1,98 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    /// <summary>
+    /// Representation of translation and rotation. 
+    /// </summary>
+    [System.Serializable]
+    public struct Displacement
+    {
+        public Vector3 position;
+        public Vector3 eulerAngles;
+
+        public Displacement(Vector3 position, Vector3 eulerAngles)
+        {
+            this.position = position;
+            this.eulerAngles = eulerAngles;
+        }
+
+        public Displacement(Vector3 position)
+        {
+            this.position = position;
+            this.eulerAngles = Vector3.zero;
+        }
+
+        public static Displacement Zero
+        {
+            get
+            {
+                return new Displacement(Vector3.zero, Vector3.zero);
+            }
+        }
+
+        public static Displacement operator +(Displacement a, Displacement b)
+        {
+            return new Displacement(a.position + b.position,
+                b.eulerAngles + a.eulerAngles);
+        }
+
+        public static Displacement operator -(Displacement a, Displacement b)
+        {
+            return new Displacement(a.position - b.position,
+                b.eulerAngles - a.eulerAngles);
+        }
+
+        public static Displacement operator -(Displacement disp)
+        {
+            return new Displacement(-disp.position, -disp.eulerAngles);
+        }
+
+        public static Displacement operator *(Displacement coords, float number)
+        {
+            return new Displacement(coords.position * number,
+                coords.eulerAngles * number);
+        }
+
+        public static Displacement operator *(float number, Displacement coords)
+        {
+            return coords * number;
+        }
+
+        public static Displacement operator /(Displacement coords, float number)
+        {
+            return new Displacement(coords.position / number,
+                coords.eulerAngles / number);
+        }
+
+        public static Displacement Scale(Displacement a, Displacement b)
+        {
+            return new Displacement(Vector3.Scale(a.position, b.position),
+                Vector3.Scale(b.eulerAngles, a.eulerAngles));
+        }
+
+        public static Displacement Lerp(Displacement a, Displacement b, float t)
+        {
+            return new Displacement(Vector3.Lerp(a.position, b.position, t),
+                Vector3.Lerp(a.eulerAngles, b.eulerAngles, t));
+        }
+
+        public Displacement ScaledBy(float posScale, float rotScale)
+        {
+            return new Displacement(position * posScale, eulerAngles * rotScale);
+        }
+
+        public Displacement Normalized
+        {
+            get
+            {
+                return new Displacement(position.normalized, eulerAngles.normalized);
+            }
+        }
+
+        public static Displacement InsideUnitSpheres()
+        {
+            return new Displacement(Random.insideUnitSphere, Random.insideUnitSphere);
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Displacement.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Displacement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22dc566280f4a704d958e931abdb9fc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Envelope.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Envelope.cs
@@ -1,0 +1,168 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    /// <summary>
+    /// Controls strength of the shake over time.
+    /// </summary>
+    public class Envelope : IAmplitudeController
+    {
+        readonly EnvelopeParams pars;
+        readonly EnvelopeControlMode controlMode;
+
+        float amplitude;
+        float targetAmplitude;
+        float sustainEndTime;
+        bool finishWhenAmplitudeZero;
+        bool finishImmediately;
+        EnvelopeState state;
+
+        /// <summary>
+        /// Creates an Envelope instance.
+        /// </summary>
+        /// <param name="pars">Envelope parameters.</param>
+        /// <param name="controlMode">Pass Auto for a single shake, or Manual for controlling strength manually.</param>
+        public Envelope(EnvelopeParams pars, float initialTargetAmplitude, EnvelopeControlMode controlMode)
+        {
+            this.pars = pars;
+            this.controlMode = controlMode;
+            SetTarget(initialTargetAmplitude);
+        }
+
+        /// <summary>
+        /// The value by which you want to multiply shake displacement.
+        /// </summary>
+        public float Intensity { get; private set; }
+
+        public bool IsFinished
+        {
+            get
+            {
+                if (finishImmediately) return true;
+                return (finishWhenAmplitudeZero || controlMode == EnvelopeControlMode.Auto)
+                    && amplitude <= 0 && targetAmplitude <= 0;
+            }
+        }
+
+        public void Finish()
+        {
+            finishWhenAmplitudeZero = true;
+            SetTarget(0);
+        }
+
+        public void FinishImmediately()
+        {
+            finishImmediately = true;
+        }
+
+        /// <summary>
+        /// Update is called every frame by the shake.
+        /// </summary>
+        public void Update(float deltaTime)
+        {
+            if (IsFinished) return;
+
+            if (state == EnvelopeState.Increase)
+            {
+                if (pars.attack > 0)
+                    amplitude += deltaTime * pars.attack;
+                if (amplitude > targetAmplitude || pars.attack <= 0)
+                {
+                    amplitude = targetAmplitude;
+                    state = EnvelopeState.Sustain;
+                    if (controlMode == EnvelopeControlMode.Auto)
+                        sustainEndTime = Time.time + pars.sustain;
+                }
+            }
+            else
+            {
+                if (state == EnvelopeState.Decrease)
+                {
+
+                    if (pars.decay > 0)
+                        amplitude -= deltaTime * pars.decay;
+                    if (amplitude < targetAmplitude || pars.decay <= 0)
+                    {
+                        amplitude = targetAmplitude;
+                        state = EnvelopeState.Sustain;
+                    }
+                }
+                else
+                {
+                    if (controlMode == EnvelopeControlMode.Auto && Time.time > sustainEndTime)
+                    {
+                        SetTarget(0);
+                    }
+                }
+            }
+
+            amplitude = Mathf.Clamp01(amplitude);
+            Intensity = Power.Evaluate(amplitude, pars.degree);
+        }
+
+        public void SetTargetAmplitude(float value)
+        {
+            if (controlMode == EnvelopeControlMode.Manual && !finishWhenAmplitudeZero)
+            {
+                SetTarget(value);
+            }
+        }
+
+        private void SetTarget(float value)
+        {
+            targetAmplitude = Mathf.Clamp01(value);
+            state = targetAmplitude > amplitude ? EnvelopeState.Increase : EnvelopeState.Decrease;
+        }
+
+
+        [System.Serializable]
+        public class EnvelopeParams
+        {
+            /// <summary>
+            /// How fast the amplitude rises.
+            /// </summary>
+            [Tooltip("How fast the amplitude increases.")]
+            public float attack = 10;
+
+            /// <summary>
+            /// How long in seconds the amplitude holds a maximum value.
+            /// </summary>
+            [Tooltip("How long in seconds the amplitude holds maximum value.")]
+            public float sustain = 0;
+
+            /// <summary>
+            /// How fast the amplitude falls.
+            /// </summary>
+            [Tooltip("How fast the amplitude decreases.")]
+            public float decay = 1f;
+
+            /// <summary>
+            /// Power in which the amplitude is raised to get intensity.
+            /// </summary>
+            [Tooltip("Power in which the amplitude is raised to get intensity.")]
+            public Degree degree = Degree.Cubic;
+        }
+
+        public enum EnvelopeControlMode { Auto, Manual }
+
+        public enum EnvelopeState { Sustain, Increase, Decrease }
+    }
+
+    public interface IAmplitudeController
+    {
+        /// <summary>
+        /// Sets value to which amplitude will move over time.
+        /// </summary>
+        void SetTargetAmplitude(float value);
+
+        /// <summary>
+        /// Sets amplitude to zero and finishes the shake when zero is reached.
+        /// </summary>
+        void Finish();
+
+        /// <summary>
+        /// Immediately finishes the shake.
+        /// </summary>
+        void FinishImmediately();
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Envelope.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Envelope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13084b7de651ead408d3f5ef8c6837b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/ICameraShake.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/ICameraShake.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    public interface ICameraShake
+    {
+        /// <summary>
+        /// Represents current position and rotation of the camera according to the shake.
+        /// </summary>
+        Displacement CurrentDisplacement { get; }
+
+        /// <summary>
+        /// Shake system will dispose the shake on the first frame when this is true.
+        /// </summary>
+        bool IsFinished { get; }
+
+        /// <summary>
+        /// CameraShaker calls this when the shake is added to the list of active shakes.
+        /// </summary>
+        void Initialize(Vector3 cameraPosition, Quaternion cameraRotation);
+
+        /// <summary>
+        /// CameraShaker calls this every frame on active shakes.
+        /// </summary>
+        void Update(float deltaTime, Vector3 cameraPosition, Quaternion cameraRotation);
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/ICameraShake.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/ICameraShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a062a4046bad80b469554a84b9b30cab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/PerlinShake.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/PerlinShake.cs
@@ -1,0 +1,144 @@
+﻿using UnityEngine;
+
+namespace CameraShake
+{
+    public class PerlinShake : ICameraShake
+    {
+        readonly Params pars;
+        readonly Envelope envelope;
+
+        public IAmplitudeController AmplitudeController;
+
+        Vector2[] seeds;
+        float time;
+        Vector3? sourcePosition;
+        float norm;
+
+        /// <summary>
+        /// Creates an instance of PerlinShake.
+        /// </summary>
+        /// <param name="parameters">Parameters of the shake.</param>
+        /// <param name="maxAmplitude">Maximum amplitude of the shake.</param>
+        /// <param name="sourcePosition">World position of the source of the shake.</param>
+        /// <param name="manualStrengthControl">Pass true if you want to control amplitude manually.</param>
+        public PerlinShake(
+            Params parameters,
+            float maxAmplitude = 1,
+            Vector3? sourcePosition = null,
+            bool manualStrengthControl = false)
+        {
+            pars = parameters;
+            envelope = new Envelope(pars.envelope, maxAmplitude,
+                manualStrengthControl ?
+                    Envelope.EnvelopeControlMode.Manual : Envelope.EnvelopeControlMode.Auto);
+            AmplitudeController = envelope;
+            this.sourcePosition = sourcePosition;
+        }
+
+        public Displacement CurrentDisplacement { get; private set; }
+        public bool IsFinished { get; private set; }
+
+        public void Initialize(Vector3 cameraPosition, Quaternion cameraRotation)
+        {
+            seeds = new Vector2[pars.noiseModes.Length];
+            norm = 0;
+            for (int i = 0; i < seeds.Length; i++)
+            {
+                seeds[i] = Random.insideUnitCircle * 20;
+                norm += pars.noiseModes[i].amplitude;
+            }
+        }
+
+        public void Update(float deltaTime, Vector3 cameraPosition, Quaternion cameraRotation)
+        {
+            if (envelope.IsFinished)
+            {
+                IsFinished = true;
+                return;
+            }
+            time += deltaTime;
+            envelope.Update(deltaTime);
+
+            Displacement disp = Displacement.Zero;
+            for (int i = 0; i < pars.noiseModes.Length; i++)
+            {
+                disp += pars.noiseModes[i].amplitude / norm *
+                    SampleNoise(seeds[i], pars.noiseModes[i].freq);
+            }
+
+            CurrentDisplacement = envelope.Intensity * Displacement.Scale(disp, pars.strength);
+            if (sourcePosition != null)
+                CurrentDisplacement *= Attenuator.Strength(pars.attenuation, sourcePosition.Value, cameraPosition);
+        }
+
+        private Displacement SampleNoise(Vector2 seed, float freq)
+        {
+            Vector3 position = new Vector3(
+                Mathf.PerlinNoise(seed.x + time * freq, seed.y),
+                Mathf.PerlinNoise(seed.x, seed.y + time * freq),
+                Mathf.PerlinNoise(seed.x + time * freq, seed.y + time * freq));
+            position -= Vector3.one * 0.5f;
+
+            Vector3 rotation = new Vector3(
+                Mathf.PerlinNoise(-seed.x - time * freq, -seed.y),
+                Mathf.PerlinNoise(-seed.x, -seed.y - time * freq),
+                Mathf.PerlinNoise(-seed.x - time * freq, -seed.y - time * freq));
+            rotation -= Vector3.one * 0.5f;
+
+            return new Displacement(position, rotation);
+        }
+
+
+        [System.Serializable]
+        public class Params
+        {
+            /// <summary>
+            /// Strength of the shake for each axis.
+            /// </summary>
+            [Tooltip("Strength of the shake for each axis.")]
+            public Displacement strength = new Displacement(Vector3.zero, new Vector3(2, 2, 0.8f));
+
+            /// <summary>
+            /// Layers of perlin noise with different frequencies.
+            /// </summary>
+            [Tooltip("Layers of perlin noise with different frequencies.")]
+            public NoiseMode[] noiseModes = { new NoiseMode(12, 1) };
+
+            /// <summary>
+            /// Strength over time.
+            /// </summary>
+            [Tooltip("Strength of the shake over time.")]
+            public Envelope.EnvelopeParams envelope;
+
+            /// <summary>
+            /// How strength falls with distance from the shake source.
+            /// </summary>
+            [Tooltip("How strength falls with distance from the shake source.")]
+            public Attenuator.StrengthAttenuationParams attenuation;
+        }
+
+
+        [System.Serializable]
+        public struct NoiseMode
+        {
+            public NoiseMode(float freq, float amplitude)
+            {
+                this.freq = freq;
+                this.amplitude = amplitude;
+            }
+
+            /// <summary>
+            /// Frequency multiplier for the noise.
+            /// </summary>
+            [Tooltip("Frequency multiplier for the noise.")]
+            public float freq;
+
+            /// <summary>
+            /// Amplitude of the mode.
+            /// </summary>
+            [Tooltip("Amplitude of the mode.")]
+            [Range(0, 1)]
+            public float amplitude;
+        }
+    }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/PerlinShake.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/PerlinShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de97a9ba28783f34cae2c44c1d4446d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Power.cs
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Power.cs
@@ -1,0 +1,24 @@
+﻿namespace CameraShake
+{
+    public static class Power
+    {
+        public static float Evaluate(float value, Degree degree)
+        {
+            switch (degree)
+            {
+                case Degree.Linear:
+                    return value;
+                case Degree.Quadratic:
+                    return value * value;
+                case Degree.Cubic:
+                    return value * value * value;
+                case Degree.Quadric:
+                    return value * value * value * value;
+                default:
+                    return value;
+            }
+        }
+    }
+
+    public enum Degree { Linear, Quadratic, Cubic, Quadric }
+}

--- a/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Power.cs.meta
+++ b/Assets/Scripts/Graphics and UI/GG Camera Shake/Runtime/Power.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae1c138ac39e5704daa47650c0a286d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sound/Conductor/Conductor.cs
+++ b/Assets/Scripts/Sound/Conductor/Conductor.cs
@@ -15,6 +15,8 @@ public class Conductor : MonoBehaviour {
     public BeatClipSO[] PlayList;
 
     private PlayerController _player;
+
+    private ScreenShake ScreenShake;
     
     private BeatClipSO CurrentBeatClip
     {
@@ -40,6 +42,7 @@ public class Conductor : MonoBehaviour {
     private bool _wasOnBeat;
 
     public int Cash = 0;
+
     public FMOD.Studio.Bus MasterBus;
 
     public int SpeedMultiplier = 1;
@@ -92,7 +95,7 @@ public class Conductor : MonoBehaviour {
 
         MyUIManager = FindObjectOfType<UIManager>();
         _stateMachine = GetComponent<BeatStateMachine>();
-
+        ScreenShake = GetComponent<ScreenShake>();
     }
 
     FMOD.Studio.EventInstance currentSong;
@@ -225,6 +228,7 @@ public class Conductor : MonoBehaviour {
     }
 
     public void ResetCombo() {
+        if (CurCombo >= 2) ScreenShake.SmallShake(); // Shake the screen!
         SetCurCombo(0);
         MyUIManager.Gauge.ResetGauge();
     }

--- a/Logs/ApiUpdaterCheck.txt
+++ b/Logs/ApiUpdaterCheck.txt
@@ -1018,3 +1018,13 @@ C# parse time         : 244ms
 candidates check time : 67ms
 console write time    : 0ms
 
+[api-updater (non-obsolete-error-filter)] 4/8/2022 7:15:19 PM : Starting /Applications/Unity/Unity.app/Contents/Tools/ScriptUpdater/APIUpdater.NonObsoleteApiUpdaterDetector.exe
+[api-updater (non-obsolete-error-filter)] 
+----------------------------------
+jit/startup time      : 700.462ms
+moved types parse time: 139ms
+candidates parse time : 4ms
+C# parse time         : 557ms
+candidates check time : 140ms
+console write time    : 1ms
+

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -6,31 +6,31 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c72191a120b3e232623707f67083debf42d
-      flags: 0
-    RecentlyUsedScenePath-1:
-      value: 22424703114646680e0b0227036c7133171e570e292529700120093aedee7a2decee22f0
-      flags: 0
-    RecentlyUsedScenePath-2:
       value: 22424703114646680e0b0227036c7119151c0165183d323f3f201c3facf53a31f6fe
       flags: 0
-    RecentlyUsedScenePath-3:
+    RecentlyUsedScenePath-1:
       value: 22424703114646680e0b0227036c7119151c0165183d323f3f201c3fb0ae2136ebf32f
       flags: 0
-    RecentlyUsedScenePath-4:
+    RecentlyUsedScenePath-2:
       value: 22424703114646680e0b0227036c6f190214106a082d2b3f633c133af6f9
       flags: 0
-    RecentlyUsedScenePath-5:
+    RecentlyUsedScenePath-3:
       value: 22424703114646680e0b0227036c6b15050311242b0f343f38271920add22d39eca923e7ee2e26
       flags: 0
-    RecentlyUsedScenePath-6:
+    RecentlyUsedScenePath-4:
       value: 22424703114646680e0b0227036c7e1c130f57077e681622283a5326ece92021
       flags: 0
-    RecentlyUsedScenePath-7:
+    RecentlyUsedScenePath-5:
       value: 22424703114646680e0b0227036c7c18041e0b65382d3524633c133af6f9
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-6:
       value: 22424703114646680e0b0227036c7e1c130f571c0b0c23266d190f36f1e53a2cf1a923e7ee2e26
+      flags: 0
+    RecentlyUsedScenePath-7:
+      value: 22424703114646680e1c05320430103704160822252b35702c271973d7c97b1fc5a715e8ea3f2d3d7931e73d0f3b4e0cf3071907f318452e091ef10102f61f1d5ee000d516c70c15c41752dbc314c5fa
+      flags: 0
+    RecentlyUsedScenePath-8:
+      value: 22424703114646680e1c05320430103704160822252b35702c271973d7c97b1fc5a715e8ea3f2d3d7931e73d0f3b4e0cf3071907f31845380501f01e10b023071ec808c454dd1115df00
       flags: 0
     RecentlyUsedScenePath-9:
       value: 22424703114646680e0b0227036c7e1c130f571e293b327e38271427fb


### PR DESCRIPTION
# Description
Screen shake is added—thanks to free resource https://github.com/gasgiant/Camera-Shake for the superior camera shake.

To set up screen shake, add the ScreenShake component to whatever game object you want to be able to shake the screen, and then reference this script and call a shake in the relevant script. Screen shake parameters, such as intensity and duration, can be modified in the ScreenShake script component in the editor.

Also, re-fixed the beat line timing so that it can be edited in the editor (and without causing the beat lines to arrive off-beat).